### PR TITLE
Fix pause event serialization, add SourceName to Track Info

### DIFF
--- a/driver/websocketdriver/pauser.go
+++ b/driver/websocketdriver/pauser.go
@@ -44,7 +44,7 @@ func NewPauser(conn *websocket.Conn) pause.Pauser {
 type pausePayload struct {
 	OP      op     `json:"op,omitempty"`
 	GuildID string `json:"guildId,omitempty"`
-	Pause   bool
+	Pause   bool   `json:"pause"`
 }
 
 func (p *pauser) SetPaused(guildID string, paused bool) error {

--- a/entity/track/info.go
+++ b/entity/track/info.go
@@ -50,4 +50,7 @@ type Info struct {
 
 	// URI is the URL or the local path to the audio source.
 	URI string `json:"uri,omitempty"`
+
+	// SourceName is the name of the audio source.
+	SourceName string `json:"sourceName,omitempty"`
 }


### PR DESCRIPTION
"Pause" field was incorrectly serialized to "Pause" instead of "pause".
Lavalink provides "sourceName" field in the track info payload
which wasn't deserialized.